### PR TITLE
Improve ctx config under small RAM(8GB) machine

### DIFF
--- a/entrypoints/content/components/DebugSettings/index.vue
+++ b/entrypoints/content/components/DebugSettings/index.vue
@@ -76,13 +76,35 @@
                 dropdownAlign="left"
               />
             </div>
+            <div class="flex flex-col gap-3 justify-start items-start">
+              Enable Context Window Size (Num ctx)
+              <Switch
+                v-model="enableNumCtx"
+                slotClass="rounded-lg border-gray-200 border bg-white"
+                itemClass="h-6 flex items-center justify-center text-xs px-2"
+                thumbClass="bg-blue-500 rounded-md"
+                activeItemClass="text-white"
+                :items="[
+                  {
+                    label: 'Enable',
+                    key: true,
+                  },
+                  {
+                    label: 'Disable',
+                    key: false,
+                    activeThumbClass: 'bg-gray-200',
+                  }
+                ]"
+              />
+            </div>
             <div class="flex gap-3 justify-start items-center">
               <div>Num ctx</div>
               <Input
                 v-model.number="numCtx"
                 type="number"
                 min="0"
-                class="border-b border-gray-200 py-1"
+                class="border-b border-gray-200 py-1 disabled:opacity-50"
+                :disabled="!enableNumCtx"
               />
             </div>
             <div class="flex gap-3 justify-start items-center">
@@ -385,6 +407,7 @@ defineProps<{
 const userConfig = await getUserConfig()
 const enabledDebug = userConfig.debug.enabled.toRef()
 const numCtx = userConfig.llm.numCtx.toRef()
+const enableNumCtx = userConfig.llm.enableNumCtx.toRef()
 const translationSystemPrompt = userConfig.translation.systemPrompt.toRef()
 const chatSystemPrompt = userConfig.llm.chatSystemPrompt.toRef()
 const summarizeSystemPrompt = userConfig.llm.summarizeSystemPrompt.toRef()

--- a/entrypoints/content/components/Settings/index.vue
+++ b/entrypoints/content/components/Settings/index.vue
@@ -463,6 +463,16 @@ watch(translationSystemPrompt, (newValue) => {
   }
 })
 
+watch(baseUrl, (newValue) => {
+  // if using server, reset numCtx to 8k and enableNumCtx to true
+  const url = new URL(newValue)
+  const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+  if (!isLocalhost) {
+    userConfig.llm.numCtx.set(8192)
+    userConfig.llm.enableNumCtx.set(true)
+  }
+})
+
 onMounted(async () => {
   testConnection()
 })

--- a/entrypoints/content/components/Settings/index.vue
+++ b/entrypoints/content/components/Settings/index.vue
@@ -464,12 +464,17 @@ watch(translationSystemPrompt, (newValue) => {
 })
 
 watch(baseUrl, (newValue) => {
+  try {
   // if using server, reset numCtx to 8k and enableNumCtx to true
-  const url = new URL(newValue)
-  const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
-  if (!isLocalhost) {
-    userConfig.llm.numCtx.set(8192)
-    userConfig.llm.enableNumCtx.set(true)
+    const url = new URL(newValue)
+    const isLocalhost = url.hostname === 'localhost' || url.hostname === '127.0.0.1'
+    if (!isLocalhost) {
+      userConfig.llm.numCtx.set(8192)
+      userConfig.llm.enableNumCtx.set(true)
+    }
+  }
+  catch {
+    // avoid error when baseUrl is not a valid url
   }
 })
 

--- a/utils/llm/models.ts
+++ b/utils/llm/models.ts
@@ -20,6 +20,7 @@ export async function getModelUserConfig() {
   const baseUrl = userConfig.llm.baseUrl.get()
   const apiKey = userConfig.llm.apiKey.get()
   const numCtx = userConfig.llm.numCtx.get()
+  const enableNumCtx = userConfig.llm.enableNumCtx.get()
   const reasoning = userConfig.llm.reasoning.get()
   if (!model) {
     throw new ModelNotFoundError()
@@ -29,6 +30,7 @@ export async function getModelUserConfig() {
     model,
     apiKey,
     numCtx,
+    enableNumCtx,
     reasoning,
   }
 }
@@ -40,6 +42,7 @@ export async function getModel(options: {
   model: string
   apiKey: string
   numCtx: number
+  enableNumCtx: boolean
   reasoning: boolean
   onLoadingModel?: (prg: ModelLoadingProgressEvent) => void
 }) {
@@ -63,14 +66,14 @@ export async function getModel(options: {
       fetch: customFetch,
     })
     model = ollama(options.model, {
-      numCtx: options.numCtx,
+      numCtx: options.enableNumCtx ? options.numCtx : undefined,
       structuredOutputs: true,
     })
   }
   else if (endpointType === 'web-llm') {
     const engine = await getWebLLMEngine({
       model: options.model as WebLLMSupportedModel,
-      contextWindowSize: options.numCtx,
+      contextWindowSize: options.enableNumCtx ? options.numCtx : undefined,
       onInitProgress(report) {
         options.onLoadingModel?.({ model: options.model, progress: report.progress, type: 'loading' })
       },

--- a/utils/user-config/index.ts
+++ b/utils/user-config/index.ts
@@ -209,16 +209,13 @@ type OnlineSearchStatus = 'force' | 'disable' | 'auto'
 async function _getUserConfig() {
   let enableNumCtx = true
 
-  try {
-    // if baseUrl is localhost and system memory is less than MIN_SYSTEM_MEMORY, disable numCtx
-    // system memory check is only available in chrome
-    // baseUrl logic run when user change baseUrl in settings, so we only need to check system memory here
+  // Disable numCtx when baseUrl is localhost and system memory is less than MIN_SYSTEM_MEMORY
+  // This is only available in chromium-based browsers
+  // baseUrl detection logic runs when user changes baseUrl in settings, so we only need to check system memory here
+  if (!import.meta.env.FIREFOX) {
     const systemMemoryInfo = await c2bRpc.getSystemMemoryInfo()
     const systemMemory = systemMemoryInfo.capacity / 1024 / 1024 / 1024 // convert to GB
     enableNumCtx = systemMemory > MIN_SYSTEM_MEMORY ? true : false
-  }
-  catch {
-    // ignore error
   }
 
   return {


### PR DESCRIPTION

# Pull Request

## Description

feat(ctx-size): improve ctx config under small RAM(8GB) machine

1. auto disable 8k context window size under small RAM(8GB) machine when using local LLM provider.
2. add toggle for enabling context window size.
3. add related config handling when editing llm server url.

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas