### PR TITLE
Refine message reasoning display logic in Assistant component

### DIFF
--- a/entrypoints/content/components/Chat/Messages/Assistant.vue
+++ b/entrypoints/content/components/Chat/Messages/Assistant.vue
@@ -57,7 +57,7 @@
           </div>
         </div>
         <div
-          v-if="message.reasoning"
+          v-if="message.reasoning && (!message.content || expanded)"
           class="wrap-anywhere border-l-2 pl-3 border-[#AEB5BD]"
           :class="expanded ? '' : 'line-clamp-3'"
         >


### PR DESCRIPTION
# Pull Request

## Description

After Thinking ends, continuing to display 3 lines of the Thinking process makes the entire response bubble unnecessarily long. Therefore, the Thinking process text should be fully collapsed once Thinking is complete.

fix(chat): refine message reasoning display logic in Assistant component

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
