### PR TITLE
fix(translation-settings): translation system prompt can not reset default

### DIFF
--- a/composables/useValueGuard.ts
+++ b/composables/useValueGuard.ts
@@ -12,5 +12,8 @@ export function useValueGuard<T>(value: Ref<T>, validator: (value: T) => { isVal
       value.value = newValue
     }
   }, { deep: true })
+  watch(value, (newValue) => {
+    v.value = newValue
+  })
   return { value: v, guardedValue: value, isValid, errorMessage }
 }

--- a/entrypoints/settings/components/TranslationSettings/index.vue
+++ b/entrypoints/settings/components/TranslationSettings/index.vue
@@ -55,6 +55,8 @@
 
 <script setup lang="tsx">
 
+import { computed } from 'vue'
+
 import ModelSelector from '@/components/ModelSelector.vue'
 import Selector from '@/components/Selector.vue'
 import Textarea from '@/components/Textarea.vue'
@@ -82,12 +84,12 @@ const { value: translationSystemPrompt, errorMessage: translationSystemPromptErr
   }
 })
 
-const resetDefaultTranslationSystemPrompt = () => {
+const resetDefaultTranslationSystemPrompt = computed(() => {
   if (translationSystemPrompt.value !== translationSystemPromptConfig.getDefault()) {
     return () => translationSystemPromptConfig.resetDefault()
   }
   return undefined
-}
+})
 
 const translationLanguageOptions = SUPPORTED_LANGUAGES.map((lang) => ({
   id: lang.code,


### PR DESCRIPTION
# Pull Request

## Description

update resetDefaultTranslationSystemPrompt to computed and improve useValueGuard integration

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)